### PR TITLE
Fix for Blaze VueComponent reassign default values

### DIFF
--- a/vue-component.js
+++ b/vue-component.js
@@ -57,7 +57,7 @@ Template.VueComponent.onRendered(function () {
         const props = DataLookup.get(() => Template.currentData(this.view), 'props', EJSON.equals) || {};
         _.each(_.keys(this.vm._props || {}), (key, i) => {
           const isDefined = !_.isUndefined(props[key]);
-          const isPreviouslyDefined = !_.isUndefined(propsData[key]);
+          const isPreviouslyDefined = propsData && !_.isUndefined(propsData[key]);
           if (isDefined || (!isDefined && isPreviouslyDefined)) {
             this.vm._props[key] = props[key];
           }


### PR DESCRIPTION
Hello.
There was a problem: with this package default props was rewrites with passed from blaze. 

for example we have component:
```html
<template lang="pug">
  .test {{ test }}
</template>

<script type="module">
export default {
  props: {
    test: {
      type: Number,
      default: 812,
    },
  },
};
</script>
```

And from blaze template we add it like `{{> VueComponent component="test"}}`

Variable "test" will be "undefined" cause it was rewrited.

I fix this problem.
Please, accept and update in atmosphere. Thank you.