### PR TITLE
Removing dependency package akryum:vue-router2

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,8 +4,5 @@ import VueBlazeTemplate from './install';
 
 Vue.use(VueBlazeTemplate);
 
-if (Package['akryum:vue-router'] || Package['akryum:vue-router2']) {
-  import './router-link';
-}
-
+import './router-link';
 import './vue-component';

--- a/package.js
+++ b/package.js
@@ -16,10 +16,5 @@ Package.onUse(function(api) {
     'peerlibrary:data-lookup@0.1.0'
   ]);
 
-  api.use([
-    'akryum:vue-router@0.2.2',
-    'akryum:vue-router2@0.1.0'
-  ], {weak: true});
-
   api.mainModule('main.js', 'client');
 });

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'vuejs:blaze-integration',
-  version: '0.2.0',
+  version: '0.3.0',
   summary: "Vue integration with Meteor's Blaze rendering engine."
 });
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'vuejs:blaze-integration',
-  version: '0.2.0',
+  version: '0.2.1',
   summary: "Vue integration with Meteor's Blaze rendering engine."
 });
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'vuejs:blaze-integration',
-  version: '0.3.0',
+  version: '0.2.0',
   summary: "Vue integration with Meteor's Blaze rendering engine."
 });
 
@@ -15,6 +15,11 @@ Package.onUse(function(api) {
     'underscore',
     'peerlibrary:data-lookup@0.1.0'
   ]);
+
+  api.use([
+    'akryum:vue-router@0.2.2',
+    'akryum:vue-router2@0.1.0'
+  ], {weak: true});
 
   api.mainModule('main.js', 'client');
 });


### PR DESCRIPTION
To make it possible to use RouterLink without dependence on the package