### PR TITLE
Support element attributes for router link

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,9 @@ This will render a link which will on click trigger page change through router.
 
 The template aims to be equivalent to [`<router-link>` Vue component](https://router.vuejs.org/en/api/router-link.html).
 For example, you can pass as `to` an object which will be resolved to the target location.
+
+It also supports adding attributes, you can add any attribue that is not known as an option for [`<router-link>` Vue component](https://router.vuejs.org/en/api/router-link.html).
+
+```handlebars
+{{#RouterLink to="/" class="my-class" data-my-info="{info: true}"}}
+```

--- a/router-link.html
+++ b/router-link.html
@@ -1,1 +1,1 @@
-<template name="RouterLink"><a href="{{href}}">{{> Template.contentBlock}}</a></template>
+<template name="RouterLink"><a {{attributes}} href="{{href}}">{{> Template.contentBlock}}</a></template>

--- a/router-link.js
+++ b/router-link.js
@@ -8,6 +8,10 @@ function topView(view) {
   return view;
 }
 
+const routerLinkOptions = [
+  'to', 'replace', 'append', 'tag', 'active-class', 'exact', 'event', 'exact-active-class',
+];
+
 Template.RouterLink.helpers({
   href() {
     const vm = topView(Template.instance().view);
@@ -15,7 +19,15 @@ Template.RouterLink.helpers({
     const args = Template.currentData();
     const {href} = vm.$router.resolve(args.to, current, args.append);
     return href;
-  }
+  },
+  attributes() {
+    const args = Template.currentData();
+    return Object.keys(args)
+      .filter(argName => routerLinkOptions.indexOf(argName) === -1)
+      .reduce((attrs, key) => {
+        return Object.assign(attrs, { [key]: args[key] });
+      }, {});
+  },
 });
 
 // Taken from vue-router's router-link component's code.


### PR DESCRIPTION
This makes `{{#RouterLink }}` pass attributes that are not `<router-link>` props to the `<a>` tag of the link.

This tries to simulate Vue in [passing non-prop attributes to the root element of the component](https://vuejs.org/v2/guide/components-props.html#Non-Prop-Attributes)